### PR TITLE
homm2_sorceress: Adjust train overflow fix

### DIFF
--- a/custom/homm2_sorceress.mml
+++ b/custom/homm2_sorceress.mml
@@ -1528,6 +1528,8 @@ g2 ;7103
 
 $7108
 ## 108
+`[190 r8]`
+_
 'leftPiano4-o1'
 'bassPianoSustain'
 v0c8.. 'leftPiano4Fade*v6,1'^32^2
@@ -1589,6 +1591,7 @@ v0e16.'leftPiano4Fade*v6,1'^32^1
 v0c16.'leftPiano4Fade*v6,1'^32^1
 ## 139 (at beat 2.5)
 ^8
+_
 ## Now at measure 3 beat 3, so time to go back to the big loop
 ]
 
@@ -1626,7 +1629,7 @@ g4
 ;7148
 
 
-{8} `r;` _
+{8}
 %e1
 ## Measure 1 lasts 1 beat
 r4
@@ -1731,7 +1734,6 @@ $8108
 ## 140, then back to the big loop
 r8
 ]
-_
 
 ## ** Jump functions **
 


### PR DESCRIPTION
Suggested fix removes the piano section's bass note holds (in channel 7) rather than removing channel 8 wholesale.